### PR TITLE
Better spacing for blocks

### DIFF
--- a/_frontend/frontsize/reactjsday-2017/widgets/talks/talk.scss
+++ b/_frontend/frontsize/reactjsday-2017/widgets/talks/talk.scss
@@ -1,5 +1,6 @@
 @include block ('talk') {
   @include float-row;
+  padding-bottom: s(4);
 
   @include media ('<tablet-small') {
     margin-left: s(-2);
@@ -25,7 +26,7 @@
         '>=tablet-large': 5
     ));
 
-    padding: s(6) s(2) s(2);
+    padding: s(6) s(2) 0;
 
     @include media ('<tablet-small') {
       padding-top: s(2);


### PR DESCRIPTION
* removed padding bottom on `talk__right` block
* added a 40px padding-bottom for each `talk` block